### PR TITLE
Refactors related to following redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- New `Iamvery.Phoenix.LiveView.TestHelpers.follow/3` function added in place of `click`'s `opts`.
+
+### Changes
+- The `opts` argument is no longer included for `Iamvery.Phoenix.LiveView.TestHelpers.click/3`.
+- The `opts` argument is no longer included for `Iamvery.Phoenix.LiveView.TestHelpers.submit_form/3` function.
+
+## 0.1.0 - [0.5.0] - 2022-10-19
+Introduction of `Iamvery.Phoenix.LiveView.TestHelpers`.
+
+[Unreleased]: https://github.com/iamvery/iamvery-elixir/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/iamvery/iamvery-elixir/releases/tag/v0.5.0

--- a/lib/iamvery/phoenix/live_view/test_helpers.ex
+++ b/lib/iamvery/phoenix/live_view/test_helpers.ex
@@ -41,17 +41,13 @@ defmodule Iamvery.Phoenix.LiveView.TestHelpers do
         {conn, {:ok, view, html}}
       end
 
-      def click({conn, {:ok, view, _html}}, selector, text \\ nil, opts \\ []) do
+      def click({conn, {:ok, view, _html}}, selector, text \\ nil) do
         html =
           view
           |> element(selector, text)
           |> render_click()
 
-        if Keyword.get(opts, :follow, false) do
-          {conn, follow_redirect(html, conn)}
-        else
-          {conn, {:ok, view, html}}
-        end
+        {conn, {:ok, view, html}}
       end
 
       def follow(session, selector, text \\ nil) do

--- a/lib/iamvery/phoenix/live_view/test_helpers.ex
+++ b/lib/iamvery/phoenix/live_view/test_helpers.ex
@@ -64,17 +64,13 @@ defmodule Iamvery.Phoenix.LiveView.TestHelpers do
         {conn, {:ok, view, html}}
       end
 
-      def submit_form({conn, {:ok, view, _html}}, selector, attributes, opts \\ []) do
+      def submit_form({conn, {:ok, view, _html}}, selector, attributes) do
         html =
           view
           |> form(selector, attributes)
           |> render_submit()
 
-        if Keyword.get(opts, :follow, true) do
-          {conn, follow_redirect(html, conn)}
-        else
-          {conn, {:ok, view, html}}
-        end
+        {conn, follow_redirect(html, conn)}
       end
     end
   end

--- a/lib/iamvery/phoenix/live_view/test_helpers.ex
+++ b/lib/iamvery/phoenix/live_view/test_helpers.ex
@@ -54,6 +54,11 @@ defmodule Iamvery.Phoenix.LiveView.TestHelpers do
         end
       end
 
+      def follow(session, selector, text \\ nil) do
+        {conn, {:ok, _view, html}} = click(session, selector, text)
+        {conn, follow_redirect(html, conn)}
+      end
+
       def change_form({conn, {:ok, view, _html}}, selector, attributes) do
         html =
           view

--- a/test/iamvery/phoenix/live_view/test_helpers_test.exs
+++ b/test/iamvery/phoenix/live_view/test_helpers_test.exs
@@ -46,7 +46,6 @@ defmodule Iamvery.Phoenix.LiveView.TestHelpersTest do
     |> assert_html("Link updated successfully")
     |> rerender()
     |> assert_html("Edit Link")
-    |> click("a", "Home", follow: true)
     |> follow("a", "Home")
     |> follow(".home")
     |> assert_html("Home")

--- a/test/iamvery/phoenix/live_view/test_helpers_test.exs
+++ b/test/iamvery/phoenix/live_view/test_helpers_test.exs
@@ -47,6 +47,8 @@ defmodule Iamvery.Phoenix.LiveView.TestHelpersTest do
     |> rerender()
     |> assert_html("Edit Link")
     |> click("a", "Home", follow: true)
+    |> follow("a", "Home")
+    |> follow(".home")
     |> assert_html("Home")
   end
 end

--- a/test/iamvery/phoenix/live_view/test_helpers_test.exs
+++ b/test/iamvery/phoenix/live_view/test_helpers_test.exs
@@ -5,7 +5,7 @@ end
 
 defmodule Phoenix.LiveViewTest do
   @moduledoc "A test fake to stand in for the real Phoenix module"
-  @html "<html>Edit Link. Link updated successfully. It can't be blank</html>"
+  @html "<html>Home. Edit Link. Link updated successfully. It can't be blank</html>"
   def live(_, _), do: {:ok, :live, @html}
   def form(:live, _, _), do: :form
   def element(:live, _, _), do: :live
@@ -46,5 +46,7 @@ defmodule Iamvery.Phoenix.LiveView.TestHelpersTest do
     |> assert_html("Link updated successfully")
     |> rerender()
     |> assert_html("Edit Link")
+    |> click("a", "Home", follow: true)
+    |> assert_html("Home")
   end
 end


### PR DESCRIPTION
# Problem
One of the main purposes of the live view helpers is to insulate readers from live view details. A primary example is the distinction of patch vs. redirect.

# Solution
The jury is still out on whether that's achievable, but I think a new function _may_ be slightly better than options. This is similar to the distinction in "change" vs. "submit" of forms.