### PR TITLE
Add follow/1 for simply following a redirect w/o click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New `follow/1` function to follow a redirect w/o click. See #10
+
 ## [0.7.0] - 2022-12-05
 
 ### Added

--- a/lib/iamvery/phoenix/live_view/test_helpers.ex
+++ b/lib/iamvery/phoenix/live_view/test_helpers.ex
@@ -70,6 +70,10 @@ defmodule Iamvery.Phoenix.LiveView.TestHelpers do
         {conn, follow_redirect(html, conn)}
       end
 
+      def follow({conn, {:ok, _view, html}}) do
+        {conn, follow_redirect(html, conn)}
+      end
+
       def change_form({conn, {:ok, view, _html}}, selector, attributes) do
         html =
           view

--- a/test/iamvery/phoenix/live_view/test_helpers_test.exs
+++ b/test/iamvery/phoenix/live_view/test_helpers_test.exs
@@ -53,6 +53,7 @@ defmodule Iamvery.Phoenix.LiveView.TestHelpersTest do
     |> assert_html("Edit Link")
     |> follow("a", "Home")
     |> follow(".home")
+    |> follow()
     |> assert_html("Home")
   end
 end


### PR DESCRIPTION
# Problem
There are cases where back-to-back redirects occur, e.g. clicking a button redirects to a page and errors which redirects somewhere else. In that case, it is convenient to be able to follow the second redirect.

# Solution
Add a `follow/1` function which simply follows the redirect returned by a previous function, e.g.

```elixir
start("/")
|> follow("Click me")
|> follow()
|> assert_visible("The click failed, but you've been taken to a safe place")
```