### PR TITLE
Fix follow/1 function

### DIFF
--- a/lib/iamvery/phoenix/live_view/test_helpers.ex
+++ b/lib/iamvery/phoenix/live_view/test_helpers.ex
@@ -70,8 +70,8 @@ defmodule Iamvery.Phoenix.LiveView.TestHelpers do
         {conn, follow_redirect(html, conn)}
       end
 
-      def follow({conn, {:ok, _view, html}}) do
-        {conn, follow_redirect(html, conn)}
+      def follow({conn, redirect}) do
+        {conn, follow_redirect(redirect, conn)}
       end
 
       def change_form({conn, {:ok, view, _html}}, selector, attributes) do

--- a/test/iamvery/phoenix/live_view/test_helpers_test.exs
+++ b/test/iamvery/phoenix/live_view/test_helpers_test.exs
@@ -15,6 +15,7 @@ defmodule Phoenix.LiveViewTest do
   def has_element?(:live, ".no", _), do: false
   def has_element?(:live, _, nil), do: true
   def follow_redirect(@html, :conn), do: {:ok, :live, @html}
+  def follow_redirect(redirect, :conn), do: redirect
   def render(:live), do: @html
   def render_click(:live), do: @html
   def render_change(:form), do: @html


### PR DESCRIPTION
Redirects are in the form {:error, {:redirect, ...}} so the current definition is incorrect.